### PR TITLE
Plugin doesn't filter input files by test regexp in options

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var SourceMapConsumer = require("source-map").SourceMapConsumer;
 var SourceMapSource = require("webpack-sources").SourceMapSource;
 var RawSource = require("webpack-sources").RawSource;
+var ModuleFilenameHelpers = require("webpack/lib/ModuleFilenameHelpers");
 
 var transform = require('es3ify').transform;
 
@@ -34,7 +35,7 @@ Es3ifyPlugin.prototype.apply = function(compiler) {
 			compilation.additionalChunkAssets.forEach(function(file) {
 				files.push(file);
 			});
-			// files = files.filter(ModuleFilenameHelpers.matchObject.bind(undefined, options));
+			files = files.filter(ModuleFilenameHelpers.matchObject.bind(undefined, options));
 			files.forEach(function(file) {
 				try {
 					var asset = compilation.assets[file];


### PR DESCRIPTION
I have a webpack configuration with ExtractTextPlugin:

```
var ES3ifyPlugin = require('es3ify-webpack-plugin');
var ExtractTextPlugin = require("extract-text-webpack-plugin");

module.exports = {
    entry: {
        builder: './src/builder.jsx'
    },
    output: {
        path: '.',
        filename: './[name].js',
        chunkFilename: '[id].js',
        libraryTarget: 'amd'
    },
    resolve: {
        extensions: ['', '.js', '.jsx']
    },
    module: {
        loaders: [
            {test: /\.(woff|woff2|ttf|eot|svg)$/, loader: 'file?name=fonts/[name].[ext]'},
            {test: /\.less$/, loader: ExtractTextPlugin.extract('style', 'css!less')},
            {
                test: /\.jsx?$/,
                exclude: /node_modules/,
                loader: 'babel',
                query: {
                    presets: ['es2015', 'react'],
                    plugins: [
                        'transform-export-extensions',
                        'transform-object-rest-spread',
                        'transform-es3-property-literals',
                        'transform-es3-member-expression-literals'
                    ]
                }
            }
        ]
    },
    plugins: [
        new ExtractTextPlugin("[name].css"),
        new ES3ifyPlugin({test: /\.jsx?$/})
    ]
};

```

But you plugin tries to transform CSS files.
I found out that your plugin could receive `test` option with regex, and default value is `/\.js($|\?)/i`, but this regexp isn't used in code.
